### PR TITLE
feat(React): Allow no destructuring assignment

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ module.exports = {
   rules: {
     "jsx-a11y/href-no-hash": 0,
     "react/jsx-filename-extension": "off",
+    "react/destructuring-assignment": 0,
     "import/extensions": "never",
     "no-console": [
       "error",


### PR DESCRIPTION
That will allow patterns like:
```jsx
<div>{this.context.foo}</div>;
```

Instead: 
```jsx
const { foo } = this.context 
<div>{foo}</div>;
```

## Why?
Because it's suck.
Besides when the component is using redux, a variable name is used three times:
- Import actions;
- mapDispatchToProps;
- Method into the component;

When this rule is enabling, the `eslint` forces to destructuring the action, once it's not allowed to call the action directly from `this.props.action()`. But when the action is destructed, there are two variable with the same name (import and inside the method), then you're forced to rename the actions, which doesn't make much sense;

Plus, there is another great point, freedom to write the code as you want. That won't avoid any bugs, it's just a code style;


