### PR TITLE
feat(ES6): Allow use return

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ module.exports = {
   extends: ["airbnb", "prettier", "prettier/react"],
   plugins: ["react", "prettier", "flowtype"],
   rules: {
+    "arrow-body-style": 0,
     "jsx-a11y/href-no-hash": 0,
     "react/jsx-filename-extension": "off",
     "react/destructuring-assignment": 0,


### PR DESCRIPTION
Enforces no braces around the function body (constrains arrow functions to the role of returning an expression)

```js
const foo = n => {
    return n;
};
```

## Why?
It sucks too.
When we're debugging a new application which has a return (map, reduce, arrays method...) is very common to put a console before the return. Once this rule is enabling, the developer is forced to write a return after. 

But when the console is removed, the return is removed too. However it doesn't take long, it needs to write a console or another statement again, then the process repeats more one time. It's a little detail that costs time.